### PR TITLE
feat: migrate to portal-rest Java SDK 0.4.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,4 +39,5 @@ build/
 .DS_Store
 
 # nix
-result
+resultnode_modules/
+package-lock.json

--- a/README.MD
+++ b/README.MD
@@ -19,28 +19,28 @@ A full-stack reference implementation showing how to integrate Portal into a web
 ## Prerequisites
 
 - Docker and Docker Compose
-- [Portal SDK Daemon](https://github.com/PortalTechnologiesInc/lib) (`getportal/sdk-daemon`) running and reachable
+- [Portal REST service](https://github.com/PortalTechnologiesInc/lib) (`getportal/sdk-daemon`) running and reachable
 - [Portal app](https://getportal.cc) on your phone
 
 ---
 
 ## Running with Docker
 
-**Option A — sdk-daemon on the same host (recommended):**
+**Option A — portal-rest on the same host (recommended):**
 
 ```bash
 docker compose --profile host up
 ```
 
-Portal demo at `http://localhost:7070`. Connects to sdk-daemon at `ws://localhost:7000/ws`.
+Portal demo at `http://localhost:7070`. Connects to portal-rest at `http://localhost:3000`.
 
-**Option B — sdk-daemon reachable via network:**
+**Option B — portal-rest reachable via network:**
 
 ```bash
 docker compose up
 ```
 
-sdk-daemon must listen on `0.0.0.0:7000` (not `127.0.0.1`) so the container can reach it via `host.docker.internal`.
+portal-rest must listen on `0.0.0.0:3000` (not `127.0.0.1`) so the container can reach it via `host.docker.internal`.
 
 ---
 
@@ -48,23 +48,23 @@ sdk-daemon must listen on `0.0.0.0:7000` (not `127.0.0.1`) so the container can 
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `REST_WS_ENDPOINT` | WebSocket URL of the running sdk-daemon | `ws://host.docker.internal:7000/ws` |
-| `REST_TOKEN` | Auth token (must match `PORTAL__AUTH__AUTH_TOKEN` on sdk-daemon) | `my-static-token` |
+| `REST_URL` | HTTP URL of the running portal-rest service | `http://host.docker.internal:3000` |
+| `REST_TOKEN` | Auth token (must match `PORTAL__AUTH__AUTH_TOKEN` on portal-rest) | `my-static-token` |
 | `DB_PATH` | Directory for the local SQLite database | `/home/user/portal/demo` |
 
 Edit the values in `docker-compose.yml` or pass them via environment before running.
 
 ---
 
-## Running sdk-daemon
+## Running portal-rest
 
-If you don't have sdk-daemon running yet:
+If you don't have portal-rest running yet:
 
 ```bash
-docker run -d -p 7000:3000 \
+docker run -d -p 3000:3000 \
   -e PORTAL__AUTH__AUTH_TOKEN=my-static-token \
   -e PORTAL__NOSTR__PRIVATE_KEY=your-nostr-private-key-hex \
-  getportal/sdk-daemon:0.3.0
+  getportal/sdk-daemon:0.4.1
 ```
 
 > Generate a Nostr private key with `nak generate` or any Nostr tool.
@@ -84,12 +84,12 @@ npm install
 npm run dev
 ```
 
-Set `REST_WS_ENDPOINT`, `REST_TOKEN`, and `DB_PATH` as environment variables before starting the backend.
+Set `REST_URL`, `REST_TOKEN`, and `DB_PATH` as environment variables before starting the backend.
 
 ---
 
 ## Related
 
-- [Portal lib & SDK Daemon](https://github.com/PortalTechnologiesInc/lib) — source for `getportal/sdk-daemon` and the TypeScript SDK
-- [Java SDK](https://github.com/PortalTechnologiesInc/java-sdk) — used by this demo
+- [Portal lib & REST service](https://github.com/PortalTechnologiesInc/lib) — source for `getportal/sdk-daemon` and the TypeScript SDK
+- [Java SDK](https://github.com/PortalTechnologiesInc/java-sdk) — used by this demo (v0.4.1)
 - [Documentation](https://portaltechnologiesinc.github.io/lib/)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,10 @@
-# Portal SDK connects to Portal over WebSocket. From inside the container you have two options:
+# Portal SDK connects to portal-rest over HTTP.
 #
-# 1) host network (recommended if Portal runs on host): use profile "host"
+# 1) host network (recommended if portal-rest runs on host): use profile "host"
 #    docker compose --profile host up
-#    Portal can listen on 127.0.0.1:7000; container shares host network so localhost works.
+#    portal-rest can listen on 127.0.0.1:3000; container shares host network so localhost works.
 #
-# 2) bridge network: Portal must listen on 0.0.0.0:7000 (not 127.0.0.1) so the container
+# 2) bridge network: portal-rest must listen on 0.0.0.0:3000 (not 127.0.0.1) so the container
 #    can reach it via host.docker.internal.
 
 services:
@@ -21,13 +21,13 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
-      # Bridge: Portal must listen on 0.0.0.0:7000. Or use: docker compose --profile host up
-      REST_WS_ENDPOINT: ws://host.docker.internal:7000/ws
+      # Bridge: portal-rest must listen on 0.0.0.0:3000. Or use: docker compose --profile host up
+      REST_URL: http://host.docker.internal:3000
       REST_TOKEN: my-static-token
       DB_PATH: /home/user/portal/demo
     tty: true
 
-  # Host network: use when Portal runs on host (127.0.0.1:7000). App at http://localhost:7070/
+  # Host network: use when portal-rest runs on host (127.0.0.1:3000). App at http://localhost:7070/
   portal-demo-host:
     profiles:
       - host
@@ -40,7 +40,7 @@ services:
     volumes:
       - portal-demo-volume:/home/user/portal/demo
     environment:
-      REST_WS_ENDPOINT: ws://localhost:7000/ws
+      REST_URL: http://localhost:3000
       REST_TOKEN: my-static-token
       DB_PATH: /home/user/portal/demo
     tty: true

--- a/flake.nix
+++ b/flake.nix
@@ -40,7 +40,7 @@
             version = "1.0-SNAPSHOT";
             src = ./.;
 
-            mvnHash = "sha256-dj4osxBTDTuLznL9di3fbJst69VXMtYSs2WkorwFwZY=";
+            mvnHash = "sha256-4yT1zhqQXT1UFU/ztgCQ0nA+yDDvbphPqSxGmk/QSls=";
             nativeBuildInputs = [ pkgs.makeWrapper ];
 
             preBuild = ''

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
         <dependency>
             <groupId>com.github.PortalTechnologiesInc</groupId>
             <artifactId>java-sdk</artifactId>
-            <version>0.3.0</version>
+            <version>0.4.1</version>
         </dependency>
         <dependency>
             <groupId>io.javalin</groupId>

--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -1,233 +1,169 @@
 package cc.getportal.demo
 
-import cc.getportal.PortalSDK
-import cc.getportal.command.notification.RequestSinglePaymentNotification
-import cc.getportal.command.request.AuthenticateKeyRequest
-import cc.getportal.command.request.BurnCashuRequest
-import cc.getportal.command.request.CalculateNextOccurrenceRequest
-import cc.getportal.command.request.CloseRecurringPaymentRequest
-import cc.getportal.command.request.FetchNip05ProfileRequest
-import cc.getportal.command.request.FetchProfileRequest
-import cc.getportal.command.request.KeyHandshakeUrlRequest
-import cc.getportal.command.request.ListenClosedRecurringPaymentRequest
-import cc.getportal.command.request.MintCashuRequest
-import cc.getportal.command.request.RequestCashuRequest
-import cc.getportal.command.request.RequestRecurringPaymentRequest
-import cc.getportal.command.request.RequestSinglePaymentRequest
-import cc.getportal.command.request.SendCashuDirectRequest
-import cc.getportal.command.response.AuthenticateKeyResponse
-import cc.getportal.command.response.RequestRecurringPaymentResponse
-import cc.getportal.model.CashuResponseStatus
-import cc.getportal.model.Currency
-import cc.getportal.model.RecurrenceInfo
-import cc.getportal.model.RecurringPaymentRequestContent
-import cc.getportal.model.SinglePaymentRequestContent
+import cc.getportal.PortalClient
+import cc.getportal.PortalClientConfig
+import cc.getportal.PollOptions
+import cc.getportal.AsyncOperation
+import cc.getportal.model.*
 import io.javalin.Javalin
 import io.javalin.http.HttpStatus
 import io.javalin.http.staticfiles.Location
 import io.javalin.websocket.WsContext
 import org.slf4j.LoggerFactory
 import com.google.gson.Gson
-import java.net.URL
 import java.time.Instant
 import java.util.UUID
 import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.TimeUnit
-import kotlin.math.log
 import kotlin.system.exitProcess
 
 private val logger = LoggerFactory.getLogger("Bootstrap")
 var recurringPaymentThread: ScheduledFuture<*>? = null
 var javalinApp: Javalin? = null
-var portalSdk: PortalSDK? = null
+var portalClient: PortalClient? = null
 
 data class DaemonVersionInfo(val version: String, val git_commit: String)
 
+private fun pollOpts(): PollOptions = PollOptions.defaults().intervalMs(1000).timeoutMs(300000)
+
 fun main() {
-    // val healthEndpoint = System.getenv("REST_HEALTH_ENDPOINT")
-    // if(healthEndpoint == null) {
-    //     logger.error("missing REST_HEALTH_ENDPOINT env variable")
-    //     return
-    // }
     logger.info("Starting portal demo backend...")
 
-    val wsEndpoint = System.getenv("REST_WS_ENDPOINT")
-    if(wsEndpoint == null) {
-        logger.error("missing REST_WS_ENDPOINT env variable")
+    val restUrl = System.getenv("REST_URL")
+    if (restUrl == null) {
+        logger.error("missing REST_URL env variable")
         return
     }
 
     val token = System.getenv("REST_TOKEN")
-    if(token == null) {
+    if (token == null) {
         logger.error("missing REST_TOKEN env variable")
         return
     }
 
     // build frontend
-    if(System.getenv("DEV_MODE") == "true") {
+    if (System.getenv("DEV_MODE") == "true") {
         buildFrontend()
     }
 
     val dbPath = System.getenv("DB_PATH")
-    if(dbPath == null) {
+    if (dbPath == null) {
         logger.error("missing DB_PATH env variable")
         return
     }
 
-
     logger.info("Connecting to database...")
-
-    // connect DB
     DB.connect(dbPath, "data.db")
 
     logger.info("Connecting to Portal...")
-    // connect to Portal
-    val sdk = PortalSDK(wsEndpoint)
+    val client = PortalClient(
+        PortalClientConfig.create(restUrl, token)
+            .autoPolling(1000)
+    )
+    portalClient = client
 
-    // Fetch sdk-daemon version once at startup for display in the frontend
-    val versionUrl = wsEndpoint
-        .replace(Regex("^wss://"), "https://")
-        .replace(Regex("^ws://"), "http://")
-        .replace(Regex("/ws$"), "/version")
+    // Fetch sdk-daemon version
     val daemonVersion: DaemonVersionInfo = try {
-        val json = URL(versionUrl).readText()
-        Gson().fromJson(json, DaemonVersionInfo::class.java)
+        val v = client.version()
+        DaemonVersionInfo(v.version, v.gitCommit)
     } catch (e: Exception) {
-        logger.warn("Could not fetch daemon version from $versionUrl: ${e.message}")
+        logger.warn("Could not fetch daemon version: ${e.message}")
         DaemonVersionInfo("unknown", "unknown")
     }
     logger.info("sdk-daemon version: ${daemonVersion.version} (${daemonVersion.git_commit.take(7)})")
 
-    portalSdk = sdk
-    sdk.connect()
-    sdk.authenticate(token)
-
-    // start web app after 5 seconds
+    // start web app after a few seconds
     logger.info("Starting webserver in a few seconds...")
     Thread.sleep(1000 * 5)
-    startWebApp(sdk, daemonVersion)
+    startWebApp(client, daemonVersion)
 
+    // TODO: listenClosedRecurringPayments is not supported in the REST SDK.
+    // It was a WebSocket-specific continuous listener. Needs a webhook-based approach instead.
+    // try {
+    //     listenClosedRecurringPayments(client)
+    // } catch (e: Exception) {
+    //     logger.error("Error in listenClosedRecurringPayments", e)
+    // }
 
     try {
-        listenClosedRecurringPayments(sdk)
-    } catch (e : Exception) {
-        logger.error("Error in listenClosedRecurringPayments", e)
-    }
-
-    try {
-        startRecurringPaymentThread(sdk)
+        startRecurringPaymentThread(client)
     } catch (e: Exception) {
         logger.error("Error in startRecurringPaymentThread", e)
     }
-
 }
 
-fun listenClosedRecurringPayments(sdk: PortalSDK) {
-    sdk.sendCommand(ListenClosedRecurringPaymentRequest { notification ->
-
-        DB.getSubscriptionByPortalId(notification.subscription_id)?.let { subscription ->
-            DB.updateSubscriptionStatus(subscription.data.id, SubscriptionStatus.CANCELLED)
-
-            logger.info("Subscription cancelled by user: {}", notification.subscription_id)
-
-        }
-
-
-    }) { _, err ->
-        if (err != null) {
-            logger.error("Error listening closed subscriptions: {}", err)
-            exitProcess(1)
-        }
-
-        logger.info("Listening closed subscriptions...")
-
-    }
-}
-
-
-fun startRecurringPaymentThread(sdk: PortalSDK) {
+fun startRecurringPaymentThread(client: PortalClient) {
     val scheduler = Executors.newScheduledThreadPool(1)
     recurringPaymentThread = scheduler.scheduleAtFixedRate({
         val now = Instant.now()
-
 
         val subscriptions = DB.getDueSubscriptions(now)
         for (subscription in subscriptions) {
 
             val recentPayments = DB.getSubscriptionRecentPayments(subscription.user, subscription.data.portalSubscriptionId, limit = 3)
-            if(recentPayments.size >= 3 && recentPayments.all { it.paid == null || !it.paid }) {
-
-                logger.warn("Cancelling subscription {} due to 3 consecutive payment failures", subscription.data.portalSubscriptionId);
+            if (recentPayments.size >= 3 && recentPayments.all { it.paid == null || !it.paid }) {
+                logger.warn("Cancelling subscription {} due to 3 consecutive payment failures", subscription.data.portalSubscriptionId)
                 DB.updateSubscriptionStatus(subscription.data.id, SubscriptionStatus.FAILED)
 
-                sdk.sendCommand(CloseRecurringPaymentRequest(subscription.user, emptyList(), subscription.data.portalSubscriptionId), {
-                        res, err ->
-
-                    if(err != null) {
-                        logger.warn("Error closing recurring payment: {}", err)
-                        return@sendCommand
-                    }
-
-                })
+                try {
+                    client.closeRecurringPayment(subscription.user, emptyList(), subscription.data.portalSubscriptionId)
+                } catch (e: Exception) {
+                    logger.warn("Error closing recurring payment: {}", e.message)
+                }
                 continue
             }
 
             // REQUESTING SUBSCRIPTION INVOICE
-
             val description = "Payment for subscription ${subscription.data.portalSubscriptionId}"
 
             var currency = Currency.MILLISATS
-            if(subscription.data.currency != "Millisats") {
+            if (subscription.data.currency != "Millisats") {
                 currency = Currency.FIAT(subscription.data.currency)
             }
             val paymentId = DB.registerPayment(subscription.user, currency, subscription.data.amount, description, subscription.data.portalSubscriptionId)
-//            ctx.sendSuccess("PaymentsHistory", mapOf("history" to DB.getPaymentsHistory(userState.key)))
 
             val req = SinglePaymentRequestContent(description, subscription.data.amount, currency, subscription.data.portalSubscriptionId, null, null)
-            sdk.sendCommand(RequestSinglePaymentRequest(subscription.user, emptyList(), req) { not ->
-                val status = not.status.status;
-                when(status) {
-                    RequestSinglePaymentNotification.InvoiceStatusType.PAID -> {
-                        DB.updatePaymentStatus(paymentId, paid = true)
-//                        ctx.sendSuccess("PaymentsHistory", mapOf("history" to DB.getPaymentsHistory(userState.key)))
 
-                        sdk.sendCommand(CalculateNextOccurrenceRequest(subscription.data.frequency, now.epochSecond), { res, err ->
-                            if(err != null || res.next_occurrence == null) {
+            Thread {
+                try {
+                    val op = client.requestSinglePayment(subscription.user, emptyList(), req)
+                    val result = client.pollUntilComplete(op, pollOpts())
 
+                    when (result.status) {
+                        "paid" -> {
+                            DB.updatePaymentStatus(paymentId, paid = true)
+
+                            try {
+                                val nextOccurrence = client.calculateNextOccurrence(subscription.data.frequency, now.epochSecond)
+                                if (nextOccurrence != null) {
+                                    val nextAt = Instant.ofEpochSecond(nextOccurrence)
+                                    DB.updateSubscriptionLastPayment(subscription.data.id, now, nextAt)
+                                    logger.info("User paid invoice of subscription {}", subscription.data.portalSubscriptionId)
+                                } else {
+                                    logger.error("Error calculating next occurrence for subscription {}", subscription.data.portalSubscriptionId)
+                                }
+                            } catch (e: Exception) {
                                 logger.error("Error calculating next occurrence for subscription {}", subscription.data.portalSubscriptionId)
-                                return@sendCommand
                             }
-                            val nextOccurrence = Instant.ofEpochSecond(res.next_occurrence!!)
-                            DB.updateSubscriptionLastPayment(subscription.data.id, now, nextOccurrence)
-
-                            logger.info("User paid invoice of subscription {}", subscription.data.portalSubscriptionId)
-
-                        })
+                        }
+                        "user_approved", "user_success" -> {}
+                        else -> {
+                            DB.updatePaymentStatus(paymentId, paid = false)
+                            logger.info("User did not pay invoice of subscription {}", subscription.data.portalSubscriptionId)
+                        }
                     }
-                    RequestSinglePaymentNotification.InvoiceStatusType.USER_APPROVED, RequestSinglePaymentNotification.InvoiceStatusType.USER_SUCCESS
-                        -> {}
-                    else -> {
-                        DB.updatePaymentStatus(paymentId, paid = false)
-//                        ctx.sendSuccess("PaymentsHistory", mapOf("history" to DB.getPaymentsHistory(userState.key)))
-                        logger.info("User did not pay invoice of subscription {}", subscription.data.portalSubscriptionId)
-                    }
+                } catch (e: Exception) {
+                    logger.info("Error requesting invoice of subscription {}, {}", subscription.data.portalSubscriptionId, e.message)
                 }
-            }) { res, err ->
-                if (err != null) {
-                    logger.info("Error requesting invoice of subscription {}, {}", subscription.data.portalSubscriptionId, err)
-                    return@sendCommand
-                }
-            }
+            }.start()
         }
     }, 0, 1, TimeUnit.MINUTES)
 }
 
-fun startWebApp(sdk: PortalSDK, daemonVersion: DaemonVersionInfo) {
+fun startWebApp(client: PortalClient, daemonVersion: DaemonVersionInfo) {
     val app = Javalin.create { config ->
         run {
-
-            // dev
             config.bundledPlugins.enableCors { cors ->
                 cors.addRule {
                     it.anyHost()
@@ -236,14 +172,9 @@ fun startWebApp(sdk: PortalSDK, daemonVersion: DaemonVersionInfo) {
 
             config.spaRoot.addFile("/", "/static/index.html")
             config.staticFiles.add { staticFiles ->
-                staticFiles.hostedPath = "/"                    // change to host files on a subpath, like '/assets'
-                staticFiles.directory = "/static"               // the directory where your files are located
-                staticFiles.location = Location.CLASSPATH       // Location.CLASSPATH (jar) or Location.EXTERNAL (file system)
-//                staticFiles.precompress = false                 // if the files should be pre-compressed and cached in memory (optimization)
-//                staticFiles.aliasCheck = null                   // you can configure this to enable symlinks (= ContextHandler.ApproveAliases())
-//                staticFiles.headers = mapOf(...)                // headers that will be set for the files
-//                staticFiles.skipFileFunction = { req -> false } // you can use this to skip certain files in the dir, based on the HttpServletRequest
-//                staticFiles.mimeTypes.add(mimeType, ext)        // you can add custom mimetypes for extensions
+                staticFiles.hostedPath = "/"
+                staticFiles.directory = "/static"
+                staticFiles.location = Location.CLASSPATH
             }
         }
     }
@@ -255,7 +186,7 @@ fun startWebApp(sdk: PortalSDK, daemonVersion: DaemonVersionInfo) {
         logger.info("Shutdown hook: closing resources...")
         try {
             recurringPaymentThread?.cancel(true)
-            portalSdk?.disconnect()
+            portalClient?.close()
             DB.disconnect()
             app.stop()
         } catch (e: Exception) {
@@ -263,27 +194,6 @@ fun startWebApp(sdk: PortalSDK, daemonVersion: DaemonVersionInfo) {
         }
         logger.info("Shutdown complete.")
     })
-
-//    app.events { event ->
-//        event.serverStopped {
-//            sdk.disconnect()
-//        }
-//    }
-
-    sdk.onClose {
-        logger.error("SDK closed")
-
-        logger.info("Closing dn connection...")
-        DB.disconnect()
-
-        logger.info("Closing recurringPaymentThread...")
-        recurringPaymentThread?.cancel(true)
-
-        logger.info("Closing webserver")
-        app.stop()
-
-        exitProcess(1)
-    }
 
     app.exception(Exception::class.java) { e, ctx ->
         logger.error("Server unexpected error", e)
@@ -305,20 +215,20 @@ fun startWebApp(sdk: PortalSDK, daemonVersion: DaemonVersionInfo) {
         }
 
         ws.onMessage { ctx ->
-            if(ctx.message() == "PING") {
+            if (ctx.message() == "PING") {
                 ctx.send("PONG")
                 return@onMessage
             }
 
             val command = ctx.message().split(",")
             val cmd = command.first()
-            when(cmd) {
+            when (cmd) {
                 "GenerateQRCode" -> {
                     var staticToken: String? = command.getOrNull(1)
                     if (staticToken.isNullOrEmpty()) {
                         staticToken = null
                     }
-                    generateQR(sdk, ctx, staticToken)
+                    generateQR(client, ctx, staticToken)
                 }
                 "LoginWithNip05" -> {
                     if (command.size < 2) {
@@ -326,20 +236,19 @@ fun startWebApp(sdk: PortalSDK, daemonVersion: DaemonVersionInfo) {
                         return@onMessage
                     }
                     val nip05Address = command[1]
-                    if(nip05Address.isEmpty()) {
+                    if (nip05Address.isEmpty()) {
                         ctx.sendErr("Nip05 address can not be empty")
                         return@onMessage
                     }
 
-                    sdk.sendCommand(FetchNip05ProfileRequest(nip05Address)) { res, err ->
-                        if (err != null) {
-                            ctx.sendErr(err)
-                            return@sendCommand
+                    Thread {
+                        try {
+                            val nip05Profile = client.fetchNip05Profile(nip05Address)
+                            sendAuthRequest(client, ctx, pub = nip05Profile.public_key())
+                        } catch (e: Exception) {
+                            ctx.sendErr(e.message ?: "Error fetching NIP-05 profile")
                         }
-
-                        sendAuthRequest(sdk, ctx, pub = res.profile.public_key)
-                    }
-
+                    }.start()
                 }
                 "RequestPaymentsHistory" -> {
                     if (command.size < 2) {
@@ -348,7 +257,7 @@ fun startWebApp(sdk: PortalSDK, daemonVersion: DaemonVersionInfo) {
                     }
                     val sessionToken = command[1]
                     val userState = DB.getUserByToken(sessionToken)
-                    if(userState == null) {
+                    if (userState == null) {
                         ctx.sendErr("Not authenticated")
                         return@onMessage
                     }
@@ -361,7 +270,7 @@ fun startWebApp(sdk: PortalSDK, daemonVersion: DaemonVersionInfo) {
                     }
                     val sessionToken = command[1]
                     val userState = DB.getUserByToken(sessionToken)
-                    if(userState == null) {
+                    if (userState == null) {
                         ctx.sendErr("Not authenticated")
                         return@onMessage
                     }
@@ -374,7 +283,7 @@ fun startWebApp(sdk: PortalSDK, daemonVersion: DaemonVersionInfo) {
                     }
                     val sessionToken = command[1]
                     val userState = DB.getUserByToken(sessionToken)
-                    if(userState == null) {
+                    if (userState == null) {
                         ctx.sendErr("Not authenticated")
                         return@onMessage
                     }
@@ -383,25 +292,21 @@ fun startWebApp(sdk: PortalSDK, daemonVersion: DaemonVersionInfo) {
                     val staticAuthToken = command[3]
                     val unit = command[4]
                     val amount = command[5].toLongOrNull()
-                    if(amount == null) {
+                    if (amount == null) {
                         ctx.sendErr("Amount not a valid number")
                         return@onMessage
                     }
                     val description = command[6]
 
-                    sdk.sendCommand(MintCashuRequest(mintUrl, staticAuthToken, unit, amount, description), { res, err ->
-                        if (err != null) {
-                            ctx.sendErr(err)
-                            return@sendCommand
+                    Thread {
+                        try {
+                            val cashuToken = client.mintCashu(mintUrl, unit, amount, staticAuthToken, description)
+                            client.sendCashuDirect(userState.key, emptyList(), cashuToken)
+                            ctx.sendSuccess("CashuSent", mapOf<String, Any>())
+                        } catch (e: Exception) {
+                            ctx.sendErr(e.message ?: "Error minting/sending cashu")
                         }
-                        sdk.sendCommand(SendCashuDirectRequest(userState.key, emptyList(), res.token), { res, err ->
-                            if (err != null) {
-                                ctx.sendErr(err)
-                                return@sendCommand
-                            }
-                            ctx.sendSuccess("CashuSent", mapOf())
-                        })
-                    })
+                    }.start()
                 }
                 "BurnToken" -> {
                     if (command.size < 6) {
@@ -410,7 +315,7 @@ fun startWebApp(sdk: PortalSDK, daemonVersion: DaemonVersionInfo) {
                     }
                     val sessionToken = command[1]
                     val userState = DB.getUserByToken(sessionToken)
-                    if(userState == null) {
+                    if (userState == null) {
                         ctx.sendErr("Not authenticated")
                         return@onMessage
                     }
@@ -419,34 +324,32 @@ fun startWebApp(sdk: PortalSDK, daemonVersion: DaemonVersionInfo) {
                     val staticAuthToken = command[3]
                     val unit = command[4]
                     val amount = command[5].toLongOrNull()
-                    if(amount == null) {
+                    if (amount == null) {
                         ctx.sendErr("Amount not a valid number")
                         return@onMessage
                     }
-                    sdk.sendCommand(RequestCashuRequest(mintUrl, unit, amount, userState.key, emptyList()), { res, err ->
-                        if (err != null) {
-                            ctx.sendErr(err)
-                            return@sendCommand
-                        }
 
-                        when(res.status.status) {
-                            CashuResponseStatus.Status.SUCCESS -> {
-                                sdk.sendCommand(BurnCashuRequest(mintUrl, staticAuthToken, unit, res.status.token), { res, err ->
-                                    if (err != null) {
-                                        ctx.sendErr(err)
-                                        return@sendCommand
-                                    }
-                                    ctx.sendSuccess("BurnToken", mapOf("amount" to res.amount))
-                                })
+                    Thread {
+                        try {
+                            val op = client.requestCashu(userState.key, emptyList(), mintUrl, unit, amount)
+                            val result = client.pollUntilComplete(op, pollOpts())
+
+                            when (result.status()) {
+                                CashuResponseStatus.Status.SUCCESS -> {
+                                    val burnAmount = client.burnCashu(mintUrl, unit, result.token(), staticAuthToken)
+                                    ctx.sendSuccess("BurnToken", mapOf("amount" to burnAmount))
+                                }
+                                CashuResponseStatus.Status.INSUFFICIENT_FUNDS -> {
+                                    ctx.sendErr("Insufficient cashu tokens")
+                                }
+                                CashuResponseStatus.Status.REJECTED -> {
+                                    ctx.sendErr("Rejected cashu token request")
+                                }
                             }
-                            CashuResponseStatus.Status.INSUFFICIENT_FUNDS -> {
-                                ctx.sendErr("Insufficient cashu tokens")
-                            }
-                            CashuResponseStatus.Status.REJECTED -> {
-                                ctx.sendErr("Rejected cashu token request")
-                            }
+                        } catch (e: Exception) {
+                            ctx.sendErr(e.message ?: "Error burning token")
                         }
-                    })
+                    }.start()
                 }
                 "RequestSinglePayment" -> {
                     if (command.size < 5) {
@@ -455,51 +358,54 @@ fun startWebApp(sdk: PortalSDK, daemonVersion: DaemonVersionInfo) {
                     }
                     val sessionToken = command[1]
                     val userState = DB.getUserByToken(sessionToken)
-                    if(userState == null) {
+                    if (userState == null) {
                         ctx.sendErr("Not authenticated")
                         return@onMessage
                     }
 
                     val currencyStr = command[2]
                     var currency = Currency.MILLISATS
-                    if(currencyStr != "Millisats") {
+                    if (currencyStr != "Millisats") {
                         currency = Currency.FIAT(currencyStr)
                     }
 
                     val amount = command[3].toLongOrNull()
-                    if(amount == null) {
+                    if (amount == null) {
                         ctx.sendErr("Amount not a valid integer")
                         return@onMessage
                     }
 
                     val description = command[4]
 
-                    // Register payment before request so notification callback always has a valid paymentId (avoids race)
                     val paymentId = DB.registerPayment(userState.key, currency, amount, description, portalSubscriptionId = null)
                     val req = SinglePaymentRequestContent(description, amount, currency, null, null, null)
-                    sdk.sendCommand(RequestSinglePaymentRequest(userState.key, emptyList(), req) { not ->
-                        val status = not.status.status
-                        when(status) {
-                            RequestSinglePaymentNotification.InvoiceStatusType.PAID -> {
-                                DB.updatePaymentStatus(paymentId, paid = true)
-                                ctx.sendSuccess("PaymentsHistory", mapOf("history" to DB.getPaymentsHistory(userState.key)))
+
+                    Thread {
+                        try {
+                            val op = client.requestSinglePayment(userState.key, emptyList(), req)
+
+                            ctx.sendSuccess("PaymentsHistory", mapOf("history" to DB.getPaymentsHistory(userState.key)))
+                            ctx.sendSuccess("RequestSinglePayment", mapOf<String, Any>())
+
+                            // Wait for terminal result via polling
+                            val result = client.pollUntilComplete(op, pollOpts())
+
+                            when (result.status) {
+                                "paid" -> {
+                                    DB.updatePaymentStatus(paymentId, paid = true)
+                                    ctx.sendSuccess("PaymentsHistory", mapOf("history" to DB.getPaymentsHistory(userState.key)))
+                                }
+                                "user_approved", "user_success" -> {}
+                                else -> {
+                                    DB.updatePaymentStatus(paymentId, paid = false)
+                                    ctx.sendSuccess("PaymentsHistory", mapOf("history" to DB.getPaymentsHistory(userState.key)))
+                                }
                             }
-                            RequestSinglePaymentNotification.InvoiceStatusType.USER_APPROVED, RequestSinglePaymentNotification.InvoiceStatusType.USER_SUCCESS
-                                -> {}
-                            else -> {
-                                DB.updatePaymentStatus(paymentId, paid = false)
-                                ctx.sendSuccess("PaymentsHistory", mapOf("history" to DB.getPaymentsHistory(userState.key)))
-                            }
+                        } catch (e: Exception) {
+                            DB.updatePaymentStatus(paymentId, paid = false)
+                            ctx.sendErr(e.message ?: "Error requesting payment")
                         }
-                    }) { res, err ->
-                        if (err != null) {
-                            DB.updatePaymentStatus(paymentId, paid = false)  // request failed: mark as not paid
-                            ctx.sendErr(err)
-                            return@sendCommand
-                        }
-                        ctx.sendSuccess("PaymentsHistory", mapOf("history" to DB.getPaymentsHistory(userState.key)))
-                        ctx.sendSuccess("RequestSinglePayment", mapOf())
-                    }
+                    }.start()
                 }
                 "GetSubscriptionPayments" -> {
                     if (command.size < 3) {
@@ -508,12 +414,11 @@ fun startWebApp(sdk: PortalSDK, daemonVersion: DaemonVersionInfo) {
                     }
                     val sessionToken = command[1]
                     val userState = DB.getUserByToken(sessionToken)
-                    if(userState == null) {
+                    if (userState == null) {
                         ctx.sendErr("Not authenticated")
                         return@onMessage
                     }
                     val subscription = command[2]
-
                     ctx.sendSuccess("SubscriptionPayments", mapOf("history" to DB.getSubscriptionAllPayments(userState.key, subscription)))
                 }
                 "RequestRecurringPayment" -> {
@@ -523,19 +428,19 @@ fun startWebApp(sdk: PortalSDK, daemonVersion: DaemonVersionInfo) {
                     }
                     val sessionToken = command[1]
                     val userState = DB.getUserByToken(sessionToken)
-                    if(userState == null) {
+                    if (userState == null) {
                         ctx.sendErr("Not authenticated")
                         return@onMessage
                     }
 
                     val currencyStr = command[2]
                     var currency = Currency.MILLISATS
-                    if(currencyStr != "Millisats") {
+                    if (currencyStr != "Millisats") {
                         currency = Currency.FIAT(currencyStr)
                     }
 
                     val amount = command[3].toLongOrNull()
-                    if(amount == null) {
+                    if (amount == null) {
                         ctx.sendErr("Amount not a valid integer")
                         return@onMessage
                     }
@@ -545,41 +450,41 @@ fun startWebApp(sdk: PortalSDK, daemonVersion: DaemonVersionInfo) {
 
                     val now = Instant.now()
 
-
                     val req = RecurringPaymentRequestContent(
                         description,
                         amount,
                         currency,
-                        null, //auth token
+                        null, // auth token
                         RecurrenceInfo(null, frequency, null, now.epochSecond),
                         Instant.now().plusSeconds(3600).epochSecond,
                     )
-                    sdk.sendCommand(RequestRecurringPaymentRequest(userState.key, emptyList(), req), { res, err ->
-                        if (err != null) {
-                            ctx.sendErr(err)
-                            return@sendCommand
-                        }
-                        when(res.status.status.status) {
-                            RequestRecurringPaymentResponse.RequestRecurringPaymentStatusType.CONFIRMED -> {
-                                val subscriptionId = DB.registerSubscription(
-                                    userState.key,
-                                    currency,
-                                    amount,
-                                    frequency,
-                                    description,
-                                    nextPaymentAt = now,
-                                    portalSubscriptionId = res.status.status.subscription_id!!
-                                )
-                                ctx.sendSuccess("SubscriptionsHistory", mapOf("history" to DB.getSubscriptionsHistory(userState.key)))
 
+                    Thread {
+                        try {
+                            val op = client.requestRecurringPayment(userState.key, emptyList(), req)
+                            val result = client.pollUntilComplete(op, pollOpts())
+
+                            when (result.status.status) {
+                                "confirmed" -> {
+                                    DB.registerSubscription(
+                                        userState.key,
+                                        currency,
+                                        amount,
+                                        frequency,
+                                        description,
+                                        nextPaymentAt = now,
+                                        portalSubscriptionId = result.status.subscriptionId
+                                    )
+                                    ctx.sendSuccess("SubscriptionsHistory", mapOf("history" to DB.getSubscriptionsHistory(userState.key)))
+                                }
+                                "rejected" -> {
+                                    ctx.sendSuccess("SubscriptionsHistory", mapOf("history" to DB.getSubscriptionsHistory(userState.key)))
+                                }
                             }
-                            RequestRecurringPaymentResponse.RequestRecurringPaymentStatusType.REJECTED -> {
-                                ctx.sendSuccess("SubscriptionsHistory", mapOf("history" to DB.getSubscriptionsHistory(userState.key)))
-                            }
+                        } catch (e: Exception) {
+                            ctx.sendErr(e.message ?: "Error requesting recurring payment")
                         }
-                    })
-
-
+                    }.start()
                 }
             }
             logger.debug("OnMessage ${ctx.message()}")
@@ -587,46 +492,48 @@ fun startWebApp(sdk: PortalSDK, daemonVersion: DaemonVersionInfo) {
     })
 }
 
-fun generateQR(sdk: PortalSDK, ctx: WsContext, staticToken: String?) {
-    sdk.sendCommand(KeyHandshakeUrlRequest(staticToken, null) { notification ->
+fun generateQR(client: PortalClient, ctx: WsContext, staticToken: String?) {
+    Thread {
+        try {
+            val op = client.newKeyHandshakeUrl(staticToken, false)
+            // The streamId for key handshake is the handshake URL
+            ctx.sendSuccess("KeyHandshakeUrlRequest", mapOf("url" to op.streamId()))
 
-        val pub = notification.mainKey
-        sendAuthRequest(sdk, ctx, pub)
-    }) { res, err ->
-        if (err != null) {
-            ctx.sendErr(err)
-            return@sendCommand
+            // Wait for handshake to complete (user scans QR)
+            val result = client.pollUntilComplete(op, pollOpts())
+            val pub = result.mainKey
+            sendAuthRequest(client, ctx, pub)
+        } catch (e: Exception) {
+            ctx.sendErr(e.message ?: "Error generating QR")
         }
-        ctx.sendSuccess("KeyHandshakeUrlRequest", mapOf("url" to res.url()))
-    }
+    }.start()
 }
 
-fun sendAuthRequest(sdk: PortalSDK, ctx: WsContext, pub: String) {
-    ctx.sendSuccess("PendingAuthRequest", mapOf())
-    sdk.sendCommand(AuthenticateKeyRequest(pub, emptyList()), { res, err ->
-        if (err != null) {
-            ctx.sendErr(err)
-            ctx.sendSuccess("CancelledAuthRequest", mapOf())
-            return@sendCommand
-        }
-        if (res.event().status.status() == AuthenticateKeyResponse.AuthResponseStatusType.DECLINED) {
-            ctx.sendErr("Authentication failed. Reason: '${res.event().status().reason()}'")
-            ctx.sendSuccess("CancelledAuthRequest", mapOf())
-            return@sendCommand
-        }
-        sdk.sendCommand(FetchProfileRequest(pub)) { res, err ->
-            if (err != null) {
-                ctx.sendErr(err)
-                ctx.sendSuccess("CancelledAuthRequest", mapOf())
-                return@sendCommand
+fun sendAuthRequest(client: PortalClient, ctx: WsContext, pub: String) {
+    ctx.sendSuccess("PendingAuthRequest", mapOf<String, Any>())
+
+    Thread {
+        try {
+            val op = client.authenticateKey(pub, emptyList())
+            val result = client.pollUntilComplete(op, pollOpts())
+
+            if (result.status.status == "declined") {
+                ctx.sendErr("Authentication failed. Reason: '${result.status.reason}'")
+                ctx.sendSuccess("CancelledAuthRequest", mapOf<String, Any>())
+                return@Thread
             }
 
+            val profile = client.fetchProfile(pub)
+
             val sessionToken = UUID.randomUUID().toString()
-            val sessionState = UserSession(pub, res.profile)
+            val sessionState = UserSession(pub, profile)
             DB.insertUserToken(sessionToken, sessionState)
             ctx.sendSuccess("AuthenticateKeyRequest", mapOf("sessionToken" to sessionToken, "state" to sessionState))
+        } catch (e: Exception) {
+            ctx.sendErr(e.message ?: "Authentication error")
+            ctx.sendSuccess("CancelledAuthRequest", mapOf<String, Any>())
         }
-    })
+    }.start()
 }
 
 fun buildFrontend() {
@@ -635,7 +542,6 @@ fun buildFrontend() {
     val processBuilder = ProcessBuilder()
         .directory(java.io.File("/home/unldenis/IdeaProjects/portal-demo/frontend"))
         .command("npm", "run", "build")
-//        .inheritIO() // show output in console
 
     val environment = processBuilder.environment()
     environment["VITE_BACKEND_API_WS"] = "ws://localhost:7070/ws"
@@ -647,7 +553,6 @@ fun buildFrontend() {
         return
     }
 
-    // copy dist → static
     val distDir = java.nio.file.Paths.get("frontend", "dist")
     val staticDir = java.nio.file.Paths.get("/home/unldenis/IdeaProjects/portal-demo", "src", "main", "resources", "static")
 


### PR DESCRIPTION
## Changes

Full migration from old WebSocket `PortalSDK` to REST `PortalClient` (java-sdk 0.4.1).

### Migration summary

- **SDK**: `PortalSDK` (WebSocket, callbacks) → `PortalClient` (REST, `AsyncOperation` + `pollUntilComplete`)
- **java-sdk**: `0.3.0` → `0.4.1`
- **Init**: `PortalSDK(ws)` + `connect()` + `authenticate()` → `PortalClient(config)` with `baseUrl` + `authToken`
- **All 13 commands** migrated from callback pattern to async/polling
- **Env var**: `REST_WS_ENDPOINT` → `REST_URL` (REST, not WebSocket)

### What changed

| File | Changes |
|------|---------|
| `pom.xml` | SDK `0.3.0` → `0.4.1` |
| `Main.kt` | Full rewrite: all commands migrated to REST SDK |
| `docker-compose.yml` | `ws://` → `http://`, port `7000` → `3000` |
| `README.MD` | Updated env vars, URLs, versions |

### Notes
- `ListenClosedRecurringPaymentRequest` is commented out with TODO — it was WebSocket-specific (continuous listener). Needs webhook-based approach for REST.
- `mvn compile -DskipTests` passes ✅